### PR TITLE
Update security_groups_driver.py

### DIFF
--- a/networking_hyperv/neutron/security_groups_driver.py
+++ b/networking_hyperv/neutron/security_groups_driver.py
@@ -87,7 +87,7 @@ class HyperVSecurityGroupsDriverMixin(object):
                     port_rules.append(grp_rule)
                     continue
                 ethertype = rule['ethertype']
-                for ip, mac in self._sg_members[remote_group_id][ethertype]:
+                for ip in self._sg_members[remote_group_id][ethertype]:
                     if ip in fixed_ips:
                         continue
                     ip_rule = rule.copy()


### PR DESCRIPTION
hyperv_networking:9.0.0
*OpenStack fails to add the VMNetworkAdapterExtendedACL populated by security groups while attaching interface to the provisioned Hyper-V virtual machine or at the time of provisioning and generate Error - too many values to unpack at line 90  for ip, mac in self._sg_members[remote_group_id][ethertype]. 
**Patch included